### PR TITLE
Resolve dependency vulnerabilities

### DIFF
--- a/lib/vantiv_sftp_reports/version.rb
+++ b/lib/vantiv_sftp_reports/version.rb
@@ -3,7 +3,7 @@
 module VantivSFTPReports
   MAJOR = 0
   MINOR = 2
-  TINY  = 0
+  TINY  = 2
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze
 
   def self.version

--- a/vantiv_sftp_reports.gemspec
+++ b/vantiv_sftp_reports.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency             'net-sftp', '~> 2.1.2'
-  s.add_development_dependency 'bundler',  '~> 1.16'
+  s.add_development_dependency 'bundler',  '~> 2.2.33'
   s.add_development_dependency 'minitest', '~> 5.0'
-  s.add_development_dependency 'rake',     '~> 10.0'
+  s.add_development_dependency 'rake',     '~> 12.3.3'
   s.add_development_dependency 'rubocop',  '~> 0.56'
 end


### PR DESCRIPTION
This commit resolves vulnerabilities in rake<=12.3.2 and bundler>=1.14.0,<2.1.0, described by Dependabot [here](https://github.com/fundamerica/vantiv_sftp_reports/security/dependabot).
